### PR TITLE
Add Error implementation and variants with thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "rust-rocket"
 version = "0.3.5"
-authors = ["Tim Peters <mail@darksecond.nl>"]
+authors = ["Tim Peters <mail@darksecond.nl>", "Lauri Gustafsson <me@gustafla.space>"]
 license = "MIT"
 description = """
 A client implementation of GNU Rocket.
 """
 repository = "https://github.com/darksecond/rust-rocket"
+edition = "2018"
 
 [dependencies]
 byteorder = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ edition = "2018"
 
 [dependencies]
 byteorder = "1.3.4"
+thiserror = "1.0.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ repository = "https://github.com/darksecond/rust-rocket"
 edition = "2018"
 
 [dependencies]
-byteorder = "1"
+byteorder = "1.3.4"

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,8 +1,8 @@
 use rust_rocket::{Event, Rocket};
 use std::time::Duration;
 
-fn main() {
-    let mut rocket = Rocket::new().unwrap();
+fn main() -> Result<(), rust_rocket::Error> {
+    let mut rocket = Rocket::new()?;
     rocket.get_track_mut("test");
     rocket.get_track_mut("test2");
     rocket.get_track_mut("a:test2");

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,7 +1,4 @@
-extern crate rust_rocket;
-
 use rust_rocket::{Event, Rocket};
-
 use std::time::Duration;
 
 fn main() {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,11 +1,10 @@
 //! This module contains the main client code, including the `Rocket` type.
-use interpolation::*;
-use track::*;
+use crate::interpolation::*;
+use crate::track::*;
 
-use std;
-use std::io::Cursor;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use std::io::prelude::*;
+use std::io::Cursor;
 use std::net::TcpStream;
 
 #[derive(Copy, Clone, Debug)]
@@ -89,10 +88,10 @@ impl Rocket {
     /// # }
     /// ```
     pub fn connect(host: &str, port: u16) -> Result<Rocket, RocketErr> {
-        let stream = TcpStream::connect((host, port)).map_err(|_| RocketErr{})?;
+        let stream = TcpStream::connect((host, port)).map_err(|_| RocketErr {})?;
 
         let mut rocket = Rocket {
-            stream: stream,
+            stream,
             state: RocketState::New,
             cmd: Vec::new(),
             tracks: Vec::new(),
@@ -103,7 +102,7 @@ impl Rocket {
         rocket
             .stream
             .set_nonblocking(true)
-            .map_err(|_| RocketErr{})?;
+            .map_err(|_| RocketErr {})?;
 
         Ok(rocket)
     }
@@ -229,7 +228,7 @@ impl Rocket {
                     let cmd = cursor.read_u8().unwrap();
                     match cmd {
                         0 => {
-                            let mut track =
+                            let track =
                                 &mut self.tracks[cursor.read_u32::<BigEndian>().unwrap() as usize];
                             let row = cursor.read_u32::<BigEndian>().unwrap();
                             let value = cursor.read_f32::<BigEndian>().unwrap();
@@ -239,7 +238,7 @@ impl Rocket {
                             track.set_key(key);
                         }
                         1 => {
-                            let mut track =
+                            let track =
                                 &mut self.tracks[cursor.read_u32::<BigEndian>().unwrap() as usize];
                             let row = cursor.read_u32::<BigEndian>().unwrap();
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -68,10 +68,7 @@ impl Rocket {
     ///
     /// ```rust,no_run
     /// use rust_rocket::Rocket;
-    ///
-    /// # fn main() {
     /// let mut rocket = Rocket::new();
-    /// # }
     /// ```
     pub fn new() -> Result<Rocket, Error> {
         Rocket::connect("localhost", 1338)
@@ -90,13 +87,10 @@ impl Rocket {
     ///
     /// ```rust,no_run
     /// use rust_rocket::Rocket;
-    ///
-    /// # fn main() {
     /// let mut rocket = Rocket::connect("localhost", 1338);
-    /// # }
     /// ```
     pub fn connect(host: &str, port: u16) -> Result<Rocket, Error> {
-        let stream = TcpStream::connect((host, port)).map_err(|e| Error::Connect(e))?;
+        let stream = TcpStream::connect((host, port)).map_err(Error::Connect)?;
 
         let mut rocket = Rocket {
             stream,
@@ -110,7 +104,7 @@ impl Rocket {
         rocket
             .stream
             .set_nonblocking(true)
-            .map_err(|e| Error::SetNonblocking(e))?;
+            .map_err(Error::SetNonblocking)?;
 
         Ok(rocket)
     }
@@ -123,11 +117,9 @@ impl Rocket {
     ///
     /// ```rust,no_run
     /// # use rust_rocket::Rocket;
-    /// # fn main() {
     /// # let mut rocket = Rocket::new().unwrap();
     /// let track = rocket.get_track_mut("namespace:track");
     /// track.get_value(3.5);
-    /// # }
     /// ```
     pub fn get_track_mut(&mut self, name: &str) -> &mut Track {
         if let Some((i, _)) = self
@@ -177,7 +169,6 @@ impl Rocket {
     ///
     /// ```rust,no_run
     /// # use rust_rocket::Rocket;
-    /// # fn main() {
     /// # let mut rocket = Rocket::new().unwrap();
     /// while let Some(event) = rocket.poll_events() {
     ///     match event {
@@ -185,7 +176,6 @@ impl Rocket {
     ///         _ => (),
     ///     }
     /// }
-    /// # }
     /// ```
     pub fn poll_events(&mut self) -> Option<Event> {
         loop {
@@ -283,12 +273,10 @@ impl Rocket {
 
         self.stream
             .write_all(client_greeting)
-            .map_err(|e| Error::Handshake(e))?;
+            .map_err(Error::Handshake)?;
 
         let mut buf = [0; 12];
-        self.stream
-            .read_exact(&mut buf)
-            .map_err(|e| Error::Handshake(e))?;
+        self.stream.read_exact(&mut buf).map_err(Error::Handshake)?;
 
         if &buf == server_greeting {
             Ok(())

--- a/src/interpolation.rs
+++ b/src/interpolation.rs
@@ -33,16 +33,12 @@ impl Interpolation {
     ///
     /// ```
     /// # use rust_rocket::interpolation::Interpolation;
-    /// # fn main() {
     /// assert_eq!(Interpolation::Linear.interpolate(0.5), 0.5);
-    /// # }
     /// ```
     ///
     /// ```
     /// # use rust_rocket::interpolation::Interpolation;
-    /// # fn main() {
     /// assert_eq!(Interpolation::Step.interpolate(0.5), 0.);
-    /// # }
     /// ```
     pub fn interpolate(&self, t: f32) -> f32 {
         match *self {

--- a/src/interpolation.rs
+++ b/src/interpolation.rs
@@ -32,7 +32,6 @@ impl Interpolation {
     /// # Examples
     ///
     /// ```
-    /// # extern crate rust_rocket;
     /// # use rust_rocket::interpolation::Interpolation;
     /// # fn main() {
     /// assert_eq!(Interpolation::Linear.interpolate(0.5), 0.5);
@@ -40,7 +39,6 @@ impl Interpolation {
     /// ```
     ///
     /// ```
-    /// # extern crate rust_rocket;
     /// # use rust_rocket::interpolation::Interpolation;
     /// # fn main() {
     /// assert_eq!(Interpolation::Step.interpolate(0.5), 0.);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,8 @@
 //! This is the rust-rocket crate.
 //! It is designed to work as a client library for GNU Rocket.
 
-extern crate byteorder;
-
 pub mod client;
 pub mod interpolation;
 pub mod track;
 
-pub use client::{Event, Rocket, RocketErr};
+pub use client::{Event, Rocket, Error};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,4 +5,4 @@ pub mod client;
 pub mod interpolation;
 pub mod track;
 
-pub use client::{Event, Rocket, Error};
+pub use client::{Error, Event, Rocket};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,8 @@
 
 extern crate byteorder;
 
+pub mod client;
 pub mod interpolation;
 pub mod track;
-pub mod client;
 
-pub use client::{Rocket, RocketErr, Event};
+pub use client::{Event, Rocket, RocketErr};

--- a/src/track.rs
+++ b/src/track.rs
@@ -1,6 +1,6 @@
 //! This module contains `Key` and `Track` types.
 
-use interpolation::*;
+use crate::interpolation::*;
 
 #[derive(Debug, Clone, Copy)]
 /// The `Key` Type.
@@ -14,8 +14,8 @@ impl Key {
     /// Construct a new `Key`.
     pub fn new(row: u32, value: f32, interp: Interpolation) -> Key {
         Key {
-            row: row,
-            value: value,
+            row,
+            value,
             interpolation: interp,
         }
     }
@@ -54,7 +54,8 @@ impl Track {
         self.keys
             .iter()
             .position(|k| k.row > row)
-            .unwrap_or(self.keys.len()) - 1
+            .unwrap_or(self.keys.len())
+            - 1
     }
 
     /// Insert or update a key on a track.


### PR DESCRIPTION
Hello and thanks for this great crate. I added some error variants like issue #3 suggests. However, I also messed up your codebase by changing the edition to 2018 and adding [thiserror](https://github.com/dtolnay/thiserror) as a dependency for generating the Display implementation for errors. I also renamed RocketErr to just Error because I believe it's less redundant and more predictable that way. Sorry if you dislike some of my changes in this PR, I can rework it if needed. Also, should we handle at least some of the in-session Errors with returning a Result instead of panicing so that users can try to reconnect?